### PR TITLE
Auto-generate dev/package.json on gen-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,7 @@ $ npm publish                 # Publish main project
 $ cd dev && npm publish       # Publish dev project
 ```
 
-If you are _bootstrapping_ a new archetype, this should get you going:
-
-```sh
-$ mkdir dev
-$ touch dev/package.json
-$ vim dev/package.json
-{
-  "dependencies": {}
-}
-```
+If you are _bootstrapping_ a new archetype, a new file at `dev/package.json` will be generated for you automatically.
 
 And you should be good to run `builder-support gen-dev` in the project root.
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ This tools assumes an archetype structure of:
 
 * `package.json` - Dependencies needed for production tasks and `scripts` entry
   that has tasks for both production and development. Must have `name`,
-  `description`, `dependencies` fields.
+  `description` fields.
 * `dev/package.json` - Dependencies for development tasks only.
-  Must have a `dependencies` field.
 
 Assuming those exist, then the tool:
 

--- a/lib/dev.js
+++ b/lib/dev.js
@@ -17,6 +17,20 @@ var tryRequire = function (filePath) {
   }
 };
 
+var ensureDevPackage = function (filePath) {
+  var devPkg;
+  if (fs.existsSync(filePath)) {
+    devPkg = tryRequire(filePath);
+  } else {
+    var devDirPath = path.resolve("dev");
+    if (!fs.existsSync(devDirPath)) {
+      fs.mkdirSync(devDirPath);
+    }
+    devPkg = {dependencies: {}};
+  }
+  return devPkg;
+};
+
 /**
  * Update `target` JSON structure with fields from `source`.
  *
@@ -29,7 +43,7 @@ var updatePkg = function (source, target) {
   var pkg = JSON.parse(JSON.stringify(source));
 
   // Validation
-  ["name", "description", "dependencies"].forEach(function (name) {
+  ["name", "description"].forEach(function (name) {
     if (!pkg[name]) {
       throw new Error("Source object missing field: " + name);
     }
@@ -43,7 +57,7 @@ var updatePkg = function (source, target) {
   pkg.name += "-dev";
   pkg.description += " (Development)";
 
-  // Patch `devDependencies` into `dependencies`
+  // Copy back in `dependencies` from dev package
   pkg.dependencies = target.dependencies;
 
   // Remove scripts, dev deps, etc.
@@ -57,7 +71,7 @@ var updatePkg = function (source, target) {
 module.exports = function (callback) {
   var prodPkg = tryRequire("package.json");
   var devPath = path.resolve("dev/package.json");
-  var devPkg = tryRequire(devPath);
+  var devPkg = ensureDevPackage(devPath);
   var updatedDevPkg = updatePkg(prodPkg, devPkg);
 
   async.parallel({

--- a/lib/dev.js
+++ b/lib/dev.js
@@ -17,20 +17,6 @@ var tryRequire = function (filePath) {
   }
 };
 
-var ensureDevPackage = function (filePath) {
-  var devPkg;
-  if (fs.existsSync(filePath)) {
-    devPkg = tryRequire(filePath);
-  } else {
-    var devDirPath = path.resolve("dev");
-    if (!fs.existsSync(devDirPath)) {
-      fs.mkdirSync(devDirPath);
-    }
-    devPkg = {dependencies: {}};
-  }
-  return devPkg;
-};
-
 /**
  * Update `target` JSON structure with fields from `source`.
  *
@@ -42,23 +28,19 @@ var updatePkg = function (source, target) {
   // Clone source
   var pkg = JSON.parse(JSON.stringify(source));
 
-  // Validation
+  // Validation of source package.
   ["name", "description"].forEach(function (name) {
     if (!pkg[name]) {
       throw new Error("Source object missing field: " + name);
     }
   });
 
-  if (!target.dependencies) {
-    throw new Error("Target object missing field: dependencies");
-  }
-
   // Update with "development" names
   pkg.name += "-dev";
   pkg.description += " (Development)";
 
   // Copy back in `dependencies` from dev package
-  pkg.dependencies = target.dependencies;
+  pkg.dependencies = (target || {}).dependencies || {};
 
   // Remove scripts, dev deps, etc.
   pkg.scripts = {};
@@ -71,26 +53,40 @@ var updatePkg = function (source, target) {
 module.exports = function (callback) {
   var prodPkg = tryRequire("package.json");
   var devPath = path.resolve("dev/package.json");
-  var devPkg = ensureDevPackage(devPath);
-  var updatedDevPkg = updatePkg(prodPkg, devPkg);
 
-  async.parallel({
-    package: function (cb) {
-      fs.writeFile(devPath, JSON.stringify(updatedDevPkg, null, 2), cb);
+  async.auto({
+    ensureDevDirectory: fs.ensureDir.bind(fs, path.resolve("dev")),
+
+    readDevPackage: function (cb) {
+      var devPkg = {};
+      try {
+        devPkg = tryRequire(devPath);
+      } catch (err) {
+        // Ignore error and use default values.
+      }
+
+      cb(null, devPkg);
     },
-    gitignore: function (cb) {
+
+    writeDevPackage: ["ensureDevDirectory", "readDevPackage", function (cb, results) {
+      var updatedDevPkg = updatePkg(prodPkg, results.readDevPackage);
+      fs.writeFile(devPath, JSON.stringify(updatedDevPkg, null, 2), cb);
+    }],
+
+    writeGitignore: ["ensureDevDirectory", function (cb) {
       fs.copy(
         path.resolve(".gitignore"),
         path.resolve("dev/.gitignore"),
         cb
       );
-    },
-    readme: function (cb) {
+    }],
+
+    writeReadme: ["ensureDevDirectory", function (cb) {
       fs.copy(
         path.resolve("README.md"),
         path.resolve("dev/README.md"),
         cb
       );
-    }
+    }]
   }, callback);
 };


### PR DESCRIPTION
Since we're writing out the file again anyway we don't actually have to create an empty file before running the update, just need a good default object to work with.

I also removed the check for `"dependencies"` on the source package.json because it wasn't actually being used.

/cc @ryan-roemer 
