### PR TITLE
Chore: Refactor copying logic, add tests.

### DIFF
--- a/.eslintrc-server-test
+++ b/.eslintrc-server-test
@@ -1,0 +1,14 @@
+---
+extends:
+  - "defaults/configurations/walmart/es5-node"
+
+env:
+  mocha: true
+
+globals:
+  expect: false
+  sandbox: false
+
+rules:
+  no-unused-expressions: 0  # Disable for Chai expression assertions.
+  max-nested-callbacks: 0   # Disable for nested describes.

--- a/.istanbul.server.yml
+++ b/.istanbul.server.yml
@@ -1,0 +1,6 @@
+reporting:
+  dir: coverage/server
+  reports:
+    - lcov
+    - json
+    - text-summary

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,7 @@ before_install:
 script:
   - npm --version
   - npm run builder:check
+
+  # Send coverage reports to coveralls.
+  - ls  coverage/server/lcov.info | cat
+  - cat coverage/server/lcov.info | node_modules/.bin/coveralls || echo "Coveralls upload failed"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Travis Status][trav_img]][trav_site]
+[![Coverage Status][cov_img]][cov_site]
 
 Builder Support Tools
 =====================
@@ -61,3 +62,6 @@ And you should be good to run `builder-support gen-dev` in the project root.
 [builder]: https://github.com/FormidableLabs/builder
 [trav_img]: https://api.travis-ci.org/FormidableLabs/builder-support.svg
 [trav_site]: https://travis-ci.org/FormidableLabs/builder-support
+[cov]: https://coveralls.io
+[cov_img]: https://img.shields.io/coveralls/FormidableLabs/builder-support.svg
+[cov_site]: https://coveralls.io/r/FormidableLabs/builder-support

--- a/lib/dev.js
+++ b/lib/dev.js
@@ -7,14 +7,26 @@ var path = require("path");
 var async = require("async");
 var fs = require("fs-extra");
 
-var tryRequire = function (filePath) {
-  var resolved = path.resolve(filePath);
-  try {
-    /*eslint-disable global-require*/
-    return require(resolved);
-  } catch (err) {
-    throw new Error("Unable to import: " + resolved + " with error:\n" + err.message);
-  }
+// Production files to copy over unmutated to development directory.
+// Allowed to not exist (and not copied in that case).
+//
+// **Note**: Only copies files from root directory. We'll need to add something
+// like `ensureFile` if we want to have nested path file copies.
+var FILES = [
+  ".gitignore",
+  ".npmrc",
+  "README.md"
+];
+
+// Allow "not found", otherwise pass through errors.
+var allowNotFound = function (callback) {
+  return function (err, data) {
+    if (err && err.code === "ENOENT") {
+      return callback(null, null);
+    }
+
+    callback(err, data);
+  };
 };
 
 /**
@@ -51,42 +63,43 @@ var updatePkg = function (source, target) {
 
 // Run the dev script.
 module.exports = function (callback) {
-  var prodPkg = tryRequire("package.json");
   var devPath = path.resolve("dev/package.json");
 
   async.auto({
     ensureDevDirectory: fs.ensureDir.bind(fs, path.resolve("dev")),
 
-    readDevPackage: function (cb) {
-      var devPkg = {};
-      try {
-        devPkg = tryRequire(devPath);
-      } catch (err) {
-        // Ignore error and use default values.
-      }
-
-      cb(null, devPkg);
+    readProdPackage: function (cb) {
+      fs.readJson(path.resolve("package.json"), cb);
     },
 
-    writeDevPackage: ["ensureDevDirectory", "readDevPackage", function (cb, results) {
-      var updatedDevPkg = updatePkg(prodPkg, results.readDevPackage);
-      fs.writeFile(devPath, JSON.stringify(updatedDevPkg, null, 2), cb);
+    readDevPackage: function (cb) {
+      fs.readJson(devPath, allowNotFound(cb));
+    },
+
+    updateDevPackage: [
+      "ensureDevDirectory",
+      "readDevPackage",
+      "readProdPackage",
+      function (cb, results) {
+        try {
+          return cb(null, updatePkg(results.readProdPackage, results.readDevPackage));
+        } catch (err) {
+          return cb(err);
+        }
+      }
+    ],
+
+    writeDevPackage: ["updateDevPackage", function (cb, results) {
+      fs.writeFile(devPath, JSON.stringify(results.updateDevPackage, null, 2), cb);
     }],
 
-    writeGitignore: ["ensureDevDirectory", function (cb) {
+    // Copy all remaining files straight up.
+    copyFiles: ["ensureDevDirectory", async.map.bind(async, FILES, function (fileName, cb) {
       fs.copy(
-        path.resolve(".gitignore"),
-        path.resolve("dev/.gitignore"),
-        cb
+        path.resolve(fileName),
+        path.resolve(path.join("dev", fileName)),
+        allowNotFound(cb)
       );
-    }],
-
-    writeReadme: ["ensureDevDirectory", function (cb) {
-      fs.copy(
-        path.resolve("README.md"),
-        path.resolve("dev/README.md"),
-        cb
-      );
-    }]
+    })]
   }, callback);
 };

--- a/package.json
+++ b/package.json
@@ -17,16 +17,26 @@
   },
   "scripts": {
     "builder:lint-server": "eslint --color -c .eslintrc-server lib bin",
-    "builder:lint": "npm run builder:lint-server",
-    "builder:check": "npm run builder:lint"
+    "builder:lint-server-test": "eslint --color -c .eslintrc-server-test test",
+    "builder:lint": "npm run builder:lint-server && npm run builder:lint-server-test",
+    "builder:test": "mocha --opts test/server/mocha.opts test/server/spec",
+    "builder:test-cov": "istanbul cover --config .istanbul.server.yml _mocha -- --opts test/server/mocha.opts test/server/spec",
+    "builder:check": "npm run builder:lint && npm run builder:test",
+    "builder:check-ci": "npm run builder:lint && npm run builder:test-cov"
   },
   "dependencies": {
     "async": "^1.5.0",
     "fs-extra": "^0.26.2"
   },
   "devDependencies": {
+    "chai": "^3.4.1",
+    "coveralls": "^2.11.6",
     "eslint": "^1.10.1",
     "eslint-config-defaults": "^7.0.1",
-    "eslint-plugin-filenames": "^0.1.2"
+    "eslint-plugin-filenames": "^0.1.2",
+    "istanbul": "^0.4.2",
+    "mocha": "^2.3.4",
+    "mock-fs": "^3.6.0",
+    "sinon": "^1.17.2"
   }
 }

--- a/test/server/mocha.opts
+++ b/test/server/mocha.opts
@@ -1,0 +1,2 @@
+--require test/server/setup.js
+--recursive

--- a/test/server/setup.js
+++ b/test/server/setup.js
@@ -1,0 +1,9 @@
+"use strict";
+
+/**
+ * Test setup for server-side tests.
+ */
+var chai = require("chai");
+
+// Add test lib globals.
+global.expect = chai.expect;

--- a/test/server/spec/base.spec.js
+++ b/test/server/spec/base.spec.js
@@ -1,0 +1,26 @@
+"use strict";
+
+/**
+ * Base server unit test initialization / global before/after's.
+ *
+ * This file should be `require`'ed by all other test files.
+ *
+ * **Note**: Because there is a global sandbox server unit tests should always
+ * be run in a separate process from other types of tests.
+ */
+var sinon = require("sinon");
+
+before(function () {
+  // Set test environment
+  process.env.NODE_ENV = process.env.NODE_ENV || "test";
+});
+
+beforeEach(function () {
+  global.sandbox = sinon.sandbox.create({
+    useFakeTimers: true
+  });
+});
+
+afterEach(function () {
+  global.sandbox.restore();
+});

--- a/test/server/spec/lib/dev.spec.js
+++ b/test/server/spec/lib/dev.spec.js
@@ -1,0 +1,169 @@
+"use strict";
+
+// FS Imports: `mock-fs` _must_ come before `fs-extra`
+var mock = require("mock-fs");
+var fs = require("fs-extra");
+
+var genDev = require("../../../../lib/dev");
+
+require("../base.spec");
+
+describe("lib/dev", function () {
+
+  after(function () {
+    mock.restore();
+  });
+
+  describe("validation", function () {
+    it("fails on missing package.json", function (done) {
+      mock({
+        ".gitignore": "",
+        "README.md": ""
+      });
+
+      genDev(function (err) {
+        expect(err)
+          .to.be.ok.and
+          .to.have.property("message").and
+            .to.contain("package.json");
+
+        done();
+      });
+    });
+
+    it("fails on missing package.json:name", function (done) {
+      mock({
+        "package.json": JSON.stringify({
+          description: "foo desc",
+          dependencies: {}
+        }),
+        ".gitignore": "",
+        "README.md": ""
+      });
+
+      genDev(function (err) {
+        expect(err)
+          .to.be.ok.and
+          .to.have.property("message").and
+            .to.contain("name");
+
+        done();
+      });
+    });
+
+    it("fails on malformed package.json", function (done) {
+      mock({
+        "package.json": "{ bad: {",
+        ".gitignore": "",
+        "README.md": ""
+      });
+
+      genDev(function (err) {
+        expect(err)
+          .to.be.ok.and
+          .to.have.property("message").and
+            .to.contain("Unexpected token");
+
+        done();
+      });
+    });
+  });
+
+  describe("dev/package.json", function () {
+
+    it("creates missing dev/package.json", function (done) {
+      mock({
+        "package.json": JSON.stringify({
+          name: "foo",
+          description: "foo desc",
+          dependencies: {}
+        }),
+        ".gitignore": "IGNORE",
+        "README.md": "READ"
+      });
+
+      genDev(function (err) {
+        if (err) { return done(err); }
+
+        // NOTE: Sync methods are OK here because mocked and in-memory.
+        var devPkg = fs.readJsonSync("dev/package.json");
+        expect(devPkg).to.have.property("name", "foo-dev");
+        expect(devPkg).to.have.property("description", "foo desc (Development)");
+        expect(devPkg).to.have.property("dependencies").to.eql({});
+        expect(devPkg).to.have.property("devDependencies").to.eql({});
+
+        expect(fs.readFileSync(".gitignore").toString()).to.equal("IGNORE");
+        expect(fs.existsSync(".npmrc")).to.equal(false);
+        expect(fs.readFileSync("README.md").toString()).to.equal("READ");
+
+        done();
+      });
+    });
+
+    it("updates existing dev/package.json", function (done) {
+      mock({
+        "package.json": JSON.stringify({
+          name: "foo",
+          description: "foo desc",
+          dependencies: {}
+        }),
+        ".gitignore": "IGNORE",
+        ".npmrc": "NPM",
+        "README.md": "READ",
+        "dev/package.json": JSON.stringify({
+          dependencies: {
+            "foo": "^1.0.0"
+          }
+        })
+      });
+
+      genDev(function (err) {
+        if (err) { return done(err); }
+
+        // NOTE: Sync methods are OK here because mocked and in-memory.
+        var devPkg = fs.readJsonSync("dev/package.json");
+        expect(devPkg).to.have.property("name", "foo-dev");
+        expect(devPkg).to.have.property("description", "foo desc (Development)");
+        expect(devPkg).to.have.property("dependencies").to.eql({
+          "foo": "^1.0.0"
+        });
+        expect(devPkg).to.have.property("devDependencies").to.eql({});
+
+        expect(fs.readFileSync(".gitignore").toString()).to.equal("IGNORE");
+        expect(fs.readFileSync(".npmrc").toString()).to.equal("NPM");
+        expect(fs.readFileSync("README.md").toString()).to.equal("READ");
+
+        done();
+      });
+    });
+  });
+
+  describe("file copying", function () {
+    it("allows just package.json", function (done) {
+      mock({
+        "package.json": JSON.stringify({
+          name: "foo",
+          description: "foo desc",
+          dependencies: {}
+        })
+      });
+
+      genDev(function (err) {
+        if (err) { return done(err); }
+
+        // NOTE: Sync methods are OK here because mocked and in-memory.
+        var devPkg = fs.readJsonSync("dev/package.json");
+        expect(devPkg).to.have.property("name", "foo-dev");
+        expect(devPkg).to.have.property("description", "foo desc (Development)");
+        expect(devPkg).to.have.property("dependencies").to.eql({});
+        expect(devPkg).to.have.property("devDependencies").to.eql({});
+
+        expect(fs.existsSync(".gitignore")).to.equal(false);
+        expect(fs.existsSync(".npmrc")).to.equal(false);
+        expect(fs.existsSync("README.md")).to.equal(false);
+
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Refactor all fs method to use async fs-extra methods. Fixes #5
- Add unit tests + coverage using 'mock-fs'. Fixes #4
- Add '.npmrc' to list of files to copy from root
- Allow all source files (except package.json) to be empty

/cc @zachhale @coopy @chaseadamsio @benbayard 
