### PR TITLE
End generated dev package.json with a newline

### DIFF
--- a/lib/dev.js
+++ b/lib/dev.js
@@ -91,7 +91,7 @@ module.exports = function (callback) {
     ],
 
     writeDevPackage: ["updateDevPackage", function (cb, results) {
-      fs.writeFile(devPath, JSON.stringify(results.updateDevPackage, null, 2), cb);
+      fs.writeFile(devPath, JSON.stringify(results.updateDevPackage, null, 2) + "\n", cb);
     }],
 
     // Copy all remaining files straight up.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "async": "^1.5.0",
-    "fs-extra": "^0.26.2"
+    "fs-extra": "^0.30.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",
@@ -36,7 +36,7 @@
     "eslint-plugin-filenames": "^0.1.2",
     "istanbul": "^0.4.2",
     "mocha": "^2.3.4",
-    "mock-fs": "^3.6.0",
+    "mock-fs": "3.10.0",
     "sinon": "^1.17.2"
   }
 }


### PR DESCRIPTION
This always drives me nuts. Many editors automatically end your file with a newline upon saving, because it's good practice. This behavior also extends to `npm init` which adds a newline to the end of the `package.json` it generates. But `builder-support gen-dev` spits out JSON without a newline, which always causes an annoying extra diff for me.

Note, the tests currently fail for me even without this change. Not sure what's up:

```
  1) lib/dev dev/package.json creates missing dev/package.json:
     Uncaught TypeError: readStream.on is not a function
      at copyFile (node_modules/fs-extra/lib/copy/ncp.js:102:16)
      at node_modules/fs-extra/lib/copy/ncp.js:85:9
      at node_modules/fs-extra/lib/copy/ncp.js:209:43
      at FSReqWrap.oncomplete (node_modules/mock-fs/node/fs-4.0.0.js:72:15)
      at node_modules/mock-fs/lib/binding.js:37:9

  2) lib/dev dev/package.json updates existing dev/package.json:
     Uncaught TypeError: readStream.on is not a function
      at copyFile (node_modules/fs-extra/lib/copy/ncp.js:102:16)
      at node_modules/fs-extra/lib/copy/ncp.js:85:9
      at node_modules/fs-extra/lib/copy/ncp.js:209:43
      at FSReqWrap.oncomplete (node_modules/mock-fs/node/fs-4.0.0.js:72:15)
      at node_modules/mock-fs/lib/binding.js:37:9
```

/cc @ryan-roemer 
