### PR TITLE
Support independent dev archetype repositories

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,14 @@
 History
 =======
 
+## Unreleased
+
+* Add support for `../ARCHETYPE-dev` fallback directory if `./dev` directory
+  does not exists.
+* **Breaking Change**: Do not generate `./dev` directory on a new project if it
+  does not exist. Either a `../ARCHETYPE-dev` or `./dev` directory must already
+  exist before running `builder-support gen-dev`.
+
 ## 0.3.0
 
 * Persist `peerDependencies` in `dev/package.json`

--- a/README.md
+++ b/README.md
@@ -27,35 +27,50 @@ This tools assumes an archetype structure of:
 * `package.json` - Dependencies needed for production tasks and `scripts` entry
   that has tasks for both production and development. Must have `name`,
   `description` fields.
-* `dev/package.json` - Dependencies for development tasks only.
+* A development sub-directory or independent repository containing dependencies
+  for development tasks only.
+    * `dev/package.json`
+    * `../ARCHETYPE-dev/package.json`
 
 Assuming those exist, then the tool:
 
-* Modifies `dev/package.json` as follows:
+* Modifies `ARCHETYPE-dev/package.json` as follows:
     * Copies the root `package.json`
     * Removes `package.json:devDependencies`
-    * Replaces `package.json:dependencies` with `dev/package.json:dependencies`
-    * Updates things like the `name` field to represent `dev`
+    * Replaces `package.json:dependencies` with
+      `ARCHETYPE-dev/package.json:dependencies`
+    * Updates things like the `name` field to represent `ARCHETYPE-dev`
 
-* Copies `README.md` to `dev/README.md`
-* Copies `.gitignore` to `dev/.gitignore`
+* Copies `README.md` to `ARCHETYPE-dev/README.md`
+* Copies `.gitignore` to `ARCHETYPE-dev/.gitignore`
 
 This supports a workflow as follows:
 
 ```sh
 $ vim HISTORY.md              # Version notes
 $ vim package.json            # Bump version
-$ builder-support gen-dev     # Generate `dev/package.json|README.md|.gitignore`
+$ builder-support gen-dev     # Generate `ARCHETYPE-dev` files
 $ npm run builder:check       # Last check!
 $ git add .
 $ git commit -m "Version bump"
 $ git tag -a "vNUMBER" -m "Version NUMBER"
 $ git push && git push --tags
 $ npm publish                 # Publish main project
-$ cd dev && npm publish       # Publish dev project
+
+# Publish dev project in same repo
+$ cd dev && npm publish
+
+# (OR) Publish dev project in different, parallel repo
+$ cd ../ARCHETYPE-dev
+$ git commit -m "Version bump"
+$ git tag -a "vNUMBER" -m "Version NUMBER"
+$ git push && git push --tags
+$ npm publish                 # Publish dev project
 ```
 
-If you are _bootstrapping_ a new archetype, a new file at `dev/package.json` will be generated for you automatically.
+If you are _bootstrapping_ a new archetype you will need to ensure either that
+a `ARCHETYPE/dev` or `../ARCHETYPE-dev` directory exists. The rest of the files
+when then be properly generated into the dev project.
 
 And you should be good to run `builder-support gen-dev` in the project root.
 

--- a/lib/dev.js
+++ b/lib/dev.js
@@ -121,7 +121,7 @@ module.exports = function (callback) {
           path.resolve(path.join(results.findDevPath, fileName)),
           allowNotFound(mapCb)
         );
-      });
+      }, cb);
     }]
   }, callback);
 };

--- a/lib/dev.js
+++ b/lib/dev.js
@@ -64,21 +64,39 @@ var updatePkg = function (source, target) {
 
 // Run the dev script.
 module.exports = function (callback) {
-  var devPath = path.resolve("dev/package.json");
-
   async.auto({
-    ensureDevDirectory: fs.ensureDir.bind(fs, path.resolve("dev")),
-
     readProdPackage: function (cb) {
       fs.readJson(path.resolve("package.json"), cb);
     },
 
-    readDevPackage: function (cb) {
-      fs.readJson(devPath, allowNotFound(cb));
-    },
+    findDevPath: ["readProdPackage", function (cb, results) {
+      var pkg = results.readProdPackage;
+      var localDevPath = path.resolve("dev");
+      var externalDevPath = path.resolve("../" + pkg.name + "-dev");
+
+      fs.stat(localDevPath, function (localErr) {
+        if (localErr && localErr.code === "ENOENT") {
+          return fs.stat(externalDevPath, function (externalErr) {
+            if (externalErr) {
+              return cb(new Error("Could not find dev directories in: " + [
+                localDevPath,
+                externalDevPath
+              ].join(", ")));
+            }
+            cb(null, externalDevPath);
+          });
+        }
+        cb(localErr, localDevPath);
+      });
+    }],
+
+    readDevPackage: ["findDevPath", function (cb, results) {
+      var pkgPath = path.join(results.findDevPath, "package.json");
+      fs.readJson(pkgPath, allowNotFound(cb));
+    }],
 
     updateDevPackage: [
-      "ensureDevDirectory",
+      "findDevPath",
       "readDevPackage",
       "readProdPackage",
       function (cb, results) {
@@ -90,17 +108,20 @@ module.exports = function (callback) {
       }
     ],
 
-    writeDevPackage: ["updateDevPackage", function (cb, results) {
-      fs.writeFile(devPath, JSON.stringify(results.updateDevPackage, null, 2) + "\n", cb);
+    writeDevPackage: ["findDevPath", "updateDevPackage", function (cb, results) {
+      var pkgPath = path.join(results.findDevPath, "package.json");
+      fs.writeFile(pkgPath, JSON.stringify(results.updateDevPackage, null, 2) + "\n", cb);
     }],
 
     // Copy all remaining files straight up.
-    copyFiles: ["ensureDevDirectory", async.map.bind(async, FILES, function (fileName, cb) {
-      fs.copy(
-        path.resolve(fileName),
-        path.resolve(path.join("dev", fileName)),
-        allowNotFound(cb)
-      );
-    })]
+    copyFiles: ["findDevPath", function (cb, results) {
+      async.map(FILES, function (fileName, mapCb) {
+        fs.copy(
+          path.resolve(fileName),
+          path.resolve(path.join(results.findDevPath, fileName)),
+          allowNotFound(mapCb)
+        );
+      });
+    }]
   }, callback);
 };

--- a/test/server/spec/lib/dev.spec.js
+++ b/test/server/spec/lib/dev.spec.js
@@ -168,6 +168,83 @@ describe("lib/dev", function () {
     });
   });
 
+  describe("../ARCHETYPE-dev/package.json", function () {
+
+    it("creates missing ../ARCHETYPE-dev/package.json", function (done) {
+      mock({
+        "package.json": JSON.stringify({
+          name: "foo",
+          description: "foo desc",
+          dependencies: {}
+        }),
+        ".gitignore": "IGNORE",
+        "README.md": "READ",
+        "../foo-dev": {}
+      });
+
+      genDev(function (err) {
+        if (err) { return done(err); }
+
+        // NOTE: Sync methods are OK here because mocked and in-memory.
+        var devPkg = fs.readJsonSync("../foo-dev/package.json");
+        expect(devPkg).to.have.property("name", "foo-dev");
+        expect(devPkg).to.have.property("description", "foo desc (Development)");
+        expect(devPkg).to.have.property("dependencies").to.eql({});
+        expect(devPkg).to.have.property("devDependencies").to.eql({});
+
+        expect(fs.readFileSync(".gitignore").toString()).to.equal("IGNORE");
+        expect(fs.existsSync(".npmrc")).to.equal(false);
+        expect(fs.readFileSync("README.md").toString()).to.equal("READ");
+
+        done();
+      });
+    });
+
+    it("updates existing ../ARCHETYPE-dev/package.json", function (done) {
+      mock({
+        "package.json": JSON.stringify({
+          name: "foo",
+          description: "foo desc",
+          dependencies: {},
+          peerDependencies: {}
+        }),
+        ".gitignore": "IGNORE",
+        ".npmrc": "NPM",
+        "README.md": "READ",
+        "../foo-dev/package.json": JSON.stringify({
+          dependencies: {
+            "foo": "^1.0.0"
+          },
+          "peerDependencies": {
+            "bar": "^2.0.0"
+          }
+        })
+      });
+
+      genDev(function (err) {
+        if (err) { return done(err); }
+
+        // NOTE: Sync methods are OK here because mocked and in-memory.
+        var devPkg = fs.readJsonSync("../foo-dev/package.json");
+        expect(devPkg).to.have.property("name", "foo-dev");
+        expect(devPkg).to.have.property("description", "foo desc (Development)");
+        expect(devPkg).to.have.property("dependencies").to.eql({
+          "foo": "^1.0.0"
+        });
+        expect(devPkg).to.have.property("peerDependencies").to.eql({
+          "bar": "^2.0.0"
+        });
+        expect(devPkg).to.have.property("devDependencies").to.eql({});
+
+        expect(fs.readFileSync(".gitignore").toString()).to.equal("IGNORE");
+        expect(fs.readFileSync(".npmrc").toString()).to.equal("NPM");
+        expect(fs.readFileSync("README.md").toString()).to.equal("READ");
+
+        done();
+      });
+    });
+  });
+
   describe("file copying", function () {
     it("allows just package.json", function (done) {
       mock({

--- a/test/server/spec/lib/dev.spec.js
+++ b/test/server/spec/lib/dev.spec.js
@@ -38,7 +38,8 @@ describe("lib/dev", function () {
           dependencies: {}
         }),
         ".gitignore": "",
-        "README.md": ""
+        "README.md": "",
+        "dev": {}
       });
 
       genDev(function (err) {
@@ -46,6 +47,27 @@ describe("lib/dev", function () {
           .to.be.ok.and
           .to.have.property("message").and
             .to.contain("name");
+
+        done();
+      });
+    });
+
+    it("fails on missing ./dev + ../ARCHETYPE-dev", function (done) {
+      mock({
+        "package.json": JSON.stringify({
+          name: "foo",
+          description: "foo desc",
+          dependencies: {}
+        }),
+        ".gitignore": "",
+        "README.md": ""
+      });
+
+      genDev(function (err) {
+        expect(err)
+          .to.be.ok.and
+          .to.have.property("message").and
+            .to.contain("Could not find dev directories");
 
         done();
       });
@@ -79,7 +101,8 @@ describe("lib/dev", function () {
           dependencies: {}
         }),
         ".gitignore": "IGNORE",
-        "README.md": "READ"
+        "README.md": "READ",
+        "dev": {}
       });
 
       genDev(function (err) {
@@ -152,7 +175,8 @@ describe("lib/dev", function () {
           name: "foo",
           description: "foo desc",
           dependencies: {}
-        })
+        }),
+        "dev": {}
       });
 
       genDev(function (err) {


### PR DESCRIPTION
* Add support for `../ARCHETYPE-dev` fallback directory if `./dev` directory
  does not exists.
* **Breaking Change**: Do not generate `./dev` directory on a new project if it
  does not exist. Either a `../ARCHETYPE-dev` or `./dev` directory must already
  exist before running `builder-support gen-dev`.
