### PR TITLE
console log error

### DIFF
--- a/bin/builder-support.js
+++ b/bin/builder-support.js
@@ -16,6 +16,11 @@ if (!action) {
 }
 
 action(function (err) {
-  /*eslint-disable no-process-exit*/
+  /*eslint-disable no-process-exit, no-console*/
+
+  if (err) {
+    console.error(err);
+  }
+
   process.exit(err ? err.code || 1 : 0);
 });


### PR DESCRIPTION
Currently when builder support errors it does not log the error to the console (see below). 

```bash
$ builder-support gen-dev 
error Command failed with exit code 1.
```

With console.error() added.

```bash
$ builder-support gen-dev 
Error: Source object missing field: description
    at STACK_TRACE
error Command failed with exit code 1.
```